### PR TITLE
The Setting colorScheme actually works as expected.

### DIFF
--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -134,16 +134,15 @@ class Shopware_Plugins_Frontend_SwagFacebook_Bootstrap extends Shopware_Componen
                 'scope' => Element::SCOPE_SHOP
             )
         );
-//        TODO: Currently it seems like the setting has no effect. Check later if u can change the Facebook color-scheme
-//        $form->setElement(
-//            'select',
-//            'swagFacebook_colorscheme',
-//            array(
-//                'label' => 'Farbschema (*)',
-//                'store' => array(array(1, 'light'), array(2, 'dark')),
-//                'scope' => Shopware_Components_Form::SCOPE_SHOP
-//            )
-//        );
+        $form->setElement(
+            'select',
+            'swagFacebook_colorscheme',
+            array(
+                'label' => 'Farbschema (*)',
+                'store' => array(array(1, 'light'), array(2, 'dark')),
+                'scope' => Shopware_Components_Form::SCOPE_SHOP
+            )
+        );
 
         $this->addFormTranslations($this->getTranslations());
     }
@@ -157,8 +156,7 @@ class Shopware_Plugins_Frontend_SwagFacebook_Bootstrap extends Shopware_Componen
                 'showDetailPageComments' => array('label' => 'Show comments in detail page'),
                 'swagFacebook_showShareButton' => array('label' => 'Show share Button (*)'),
                 'swagFacebook_showFaces' => array('label' => 'Show Faces (*)'),
-                // TODO: This is the translation for the Facebook color-scheme settings below.
-//                'swagFacebook_colorscheme' => array('label' => 'color scheme')
+                'swagFacebook_colorscheme' => array('label' => 'color scheme')
             )
         );
     }

--- a/Subscriber/Frontend.php
+++ b/Subscriber/Frontend.php
@@ -85,8 +85,7 @@ class Frontend implements SubscriberInterface
         $view->assign('swagFacebook_showShareButton', $config->get('swagFacebook_showShareButton'));
         $view->assign('swagFacebook_showFaces', $config->get('swagFacebook_showFaces'));
         $view->assign('swagFacebook_showFacebookTab', $this->tabHandling($config, $request));
-        // TODO: if the setting "swagFacebookColorscheme" has a effect in the Facebook application, activate the settings in the Bootstrap for the Customer... See function "createForm()"
-        $view->assign('swagFacebook_colorScheme', ($config->get('swagFacebook_colorscheme') || 1));
+        $view->assign('swagFacebook_colorScheme', $config->get('swagFacebook_colorscheme'));
         $this->IE6Fix($view, $request->getHeader('USER_AGENT'));
     }
 


### PR DESCRIPTION
I think the problem was that the expression ($config->get('swagFacebook_colorscheme') || 1) always returned "1" (TRUE) and never "2". So this plugin always operated in "dark" colorScheme mode.
